### PR TITLE
chore(ci-versioning) Auto-update version of package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-org-people.el ident

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,37 @@ on:
       - main
 jobs:
   build:
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Compute the upcoming tag.
+        id: tag_version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dry_run: true
+
+      - name: Update version in the package
+        run: |
+          FILE="org-people.el"
+          NEW_VERSION="${{ steps.tag_version.outputs.new_tag }}"
+          echo "Updating version to $NEW_VERSION in $FILE"
+          # Use sed to replace old version
+          sed -i "s/^;; Version: .*/;; Version: $NEW_VERSION/" "$FILE"
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add "$FILE"
+          git commit -m "chore: update version to $NEW_VERSION"
+          git push
+
       - name: Bump version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create a GitHub release
         uses: ncipollo/release-action@v1
         with:

--- a/org-people.el
+++ b/org-people.el
@@ -4,7 +4,7 @@
 
 ;; Author: Steve Kemp <steve@steve.fi>
 ;; Maintainer: Steve Kemp <steve@steve.fi>
-;; Version: $Id$
+;; Version: 1.2.3
 ;; Package-Requires: ((emacs "29.1") (org "9.0"))
 ;; Keywords: outlines, contacts, people
 ;; URL: https://github.com/skx/org-people


### PR DESCRIPTION
This pull-request updates things so that we bump the version of the package within our release process.

This ensures all tags and versions match.