### PR TITLE
feat(highlighting-navigation): Support navigation and hl-line mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ If you prefer `use-package` then this works:
      ("C-c P" . org-people-summary)))
 ```
 
+If you want to enable `hl-line-mode` that is supported, and there are local configurations setup so that only people are highlighted - rather than any inline property blocks which might be present.
+
+To enable this:
+
+```
+(add-hook 'org-people-summary-mode-hook #'(lambda () (hl-line-mode 1)))
+```
+
 
 
 ## Adding Entries

--- a/org-people.el
+++ b/org-people.el
@@ -152,6 +152,16 @@
 ;;                      #'org-people-capf
 ;;                      nil t)))
 ;;
+
+;;; hl-line-mode
+
+;; If you want to enable `hl-line-mode` that is supported, and there are local
+;; configurations setup so that only people are highlighted - rather than any
+;; inline property blocks which might be present.
+;;
+;; Simply add this to your configuration:
+;;
+;;   (add-hook 'org-people-summary-mode-hook #'(lambda () (hl-line-mode 1)))
 ;;
 
 ;;; Code:


### PR DESCRIPTION
This commit introduces two changes:

* Native support for hl-line-mode
  * This will highlight *people*, but skip inline properties.
  * Add the hl-line-mode in your local config if you want it.
* Introduce (n)ext and (p)revious nagivation in org-people-summmary mode
  * This skips over inline properties.

Additionally pressing TAB within an inline property region will collapse it, rather than requiring the point to be upon the person's name.