### PR TITLE
feat(force-flush): Added binding to force flush/reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,8 @@ In brief though:
 * `f` Filter the view, by property.
   * Even properties which are not visible can be used.
   * e.g. ":ADDRESS" "Finland" will show only Finnish residents.
-* `R` reset the state of columns.
+* `r` reset the state of columns.
+* `R` clear the cache, reload all agenda files, and refresh the display.
 * `s` Initiate a search forward, via `isearch-forward`.
 * `t` Toggle visibility of a named column.
 * `T` Hide the current column.

--- a/org-people.el
+++ b/org-people.el
@@ -302,7 +302,8 @@ If nil, `org-people--parser' is called afresh every time.")
     ;; column-handling.
     (define-key map (kbd "t") #'org-people-summary--toggle-column)
     (define-key map (kbd "T") #'org-people-summary--hide-this-column)
-    (define-key map (kbd "R") #'org-people-summary-show-all-columns)
+    (define-key map (kbd "r") #'org-people-summary-show-all-columns)
+    (define-key map (kbd "R") #'org-people-summary-force-refresh)
 
     ;; setting and clearing marks.
     (define-key map (kbd "m") #'org-people-summary--mark-row)
@@ -975,6 +976,16 @@ toggled interactively.  It will not restore columns which are empty."
     (setf (org-people-column-visible col) t))
   (org-people-summary--refresh)
   (tabulated-list-print t))
+
+(defun org-people-summary-force-refresh ()
+  "Force a reload of all agenda files, and flush the cache.
+
+This removes the cache, triggers an org-reload via `org-agenda-redo-all'
+and reloads the display."
+  (interactive)
+  (org-people-clear-cache)
+  (kill-buffer (get-buffer-create org-people-summary-buffer-name))
+  (org-people-summary))
 
 (defun org-people--csv-escape (value)
   "Escape VALUE for CSV output."


### PR DESCRIPTION
We previously bound `R` to reset the state of the columns within the org-people-summary buffer.  Now we change that to just `r` and use `R` for the forcible reload of the agenda files and clearing of the cache.

Using upper-cases like that seems to make sense.